### PR TITLE
Add PrimeReact tabs

### DIFF
--- a/app/builders/basic-form-builder/attributes/lazy/component.tsx
+++ b/app/builders/basic-form-builder/attributes/lazy/component.tsx
@@ -1,0 +1,36 @@
+import { Checkbox } from "@/components/ui/checkbox";
+import { formatError, ValidationError } from "@/components/ui/validation-error";
+import { createAttributeComponent } from "@coltorapps/builder-react";
+import { lazyAttribute } from "./definition";
+
+export const LazyAttribute = createAttributeComponent(
+  lazyAttribute,
+  function LazyAttribute(props) {
+    return (
+      <div>
+        <div className="flex items-top space-x-2">
+          <Checkbox
+            id={props.attribute.name}
+            checked={props.attribute.value ?? false}
+            onCheckedChange={(checked) => {
+              if (typeof checked === "boolean") {
+                props.setValue(checked);
+              }
+            }}
+          />
+          <div className="grid gap-1.5 leading-none">
+            <label
+              htmlFor={props.attribute.name}
+              className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+            >
+              Lazy Render
+            </label>
+          </div>
+        </div>
+        <ValidationError>
+          {formatError(props.attribute.value, props.attribute.error)?._errors?.[0]}
+        </ValidationError>
+      </div>
+    );
+  },
+);

--- a/app/builders/basic-form-builder/attributes/lazy/definition.ts
+++ b/app/builders/basic-form-builder/attributes/lazy/definition.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+import { createAttribute } from "@coltorapps/builder";
+
+export const lazyAttribute = createAttribute({
+  name: "lazy",
+  validate(value) {
+    return z.boolean().optional().parse(value);
+  },
+});

--- a/app/builders/basic-form-builder/builder/component.tsx
+++ b/app/builders/basic-form-builder/builder/component.tsx
@@ -277,7 +277,7 @@ export function BasicFormBuilder() {
               {(() => {
                 const active = builderStore.getSchema().entities[activeEntityId];
                 if (active && active.type === "tabs") {
-                  return active.children?.map((childId, index) => (
+                  return active.children?.map((childId) => (
                     <AddElementDialog
                       key={childId}
                       builderStore={builderStore}

--- a/app/builders/basic-form-builder/builder/initial-schema.ts
+++ b/app/builders/basic-form-builder/builder/initial-schema.ts
@@ -47,6 +47,7 @@ export const initialSchema = {
       type: "tabs",
       attributes: {
         tabLabels: ["Info", "More"],
+        lazy: true,
       },
       children: [
         "a90e418c-2d6d-41d5-b867-14e985e881a4",

--- a/app/builders/basic-form-builder/builder/preview.tsx
+++ b/app/builders/basic-form-builder/builder/preview.tsx
@@ -9,7 +9,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { TabView, TabPanel } from "primereact/tabview";
 import { useToast } from "@/components/ui/use-toast";
 import { AlertCircle, CheckCircle2, EyeIcon } from "lucide-react";
 
@@ -86,11 +86,6 @@ function PreviewJsonCard(props: { json?: Record<string, unknown> }) {
   );
 }
 
-const tabs = {
-  form: "form",
-  values: "values",
-  schema: "schema",
-};
 
 export function Preview(props: {
   builderStore: BuilderStore<typeof basicFormBuilder>;
@@ -186,23 +181,16 @@ export function Preview(props: {
           <DialogHeader>
             <DialogTitle>Preview</DialogTitle>
           </DialogHeader>
-          <Tabs
-            defaultValue="form"
+          <TabView
             className="w-full"
-            onValueChange={(tab) => {
-              if (tab === tabs.values) {
+            onTabChange={(e) => {
+              const index = e.index;
+              if (index === 1) {
                 setPreviewValues(interpreterStore.getEntitiesValues());
               }
             }}
           >
-            <TabsList className="w-full">
-              <div className="my-px grid w-full grid-cols-3">
-                <TabsTrigger value={tabs.form}>Form</TabsTrigger>
-                <TabsTrigger value={tabs.values}>Values</TabsTrigger>
-                <TabsTrigger value={tabs.schema}>Schema</TabsTrigger>
-              </div>
-            </TabsList>
-            <TabsContent value={tabs.form}>
+            <TabPanel header="Form">
               <ScrollArea className="max-h-96 overflow-auto">
                 <Form
                   interpreterStore={interpreterStore}
@@ -210,14 +198,14 @@ export function Preview(props: {
                   onValidationFail={() => (submitAttemptedRef.current = true)}
                 />
               </ScrollArea>
-            </TabsContent>
-            <TabsContent value={tabs.values}>
+            </TabPanel>
+            <TabPanel header="Values">
               <PreviewJsonCard json={previewValues} />
-            </TabsContent>
-            <TabsContent value={tabs.schema}>
+            </TabPanel>
+            <TabPanel header="Schema">
               <PreviewJsonCard json={schema} />
-            </TabsContent>
-          </Tabs>
+            </TabPanel>
+          </TabView>
         </DialogContent>
       </Dialog>
     </div>

--- a/app/builders/basic-form-builder/entities/tabs/attributes-component.tsx
+++ b/app/builders/basic-form-builder/entities/tabs/attributes-component.tsx
@@ -1,9 +1,11 @@
 import { TabLabelsAttribute } from "../../attributes/tab-labels/component";
+import { LazyAttribute } from "../../attributes/lazy/component";
 
 export function TabsAttributes() {
   return (
     <>
       <TabLabelsAttribute />
+      <LazyAttribute />
     </>
   );
 }

--- a/app/builders/basic-form-builder/entities/tabs/component.tsx
+++ b/app/builders/basic-form-builder/entities/tabs/component.tsx
@@ -1,20 +1,20 @@
 import { createEntityComponent } from "@coltorapps/builder-react";
+import { TabPanel, TabView } from "primereact/tabview";
 import { tabsEntity } from "./definition";
 
 export const TabsEntity = createEntityComponent(
   tabsEntity,
   function TabsEntity(props) {
-    const { tabLabels } = props.entity.attributes;
+    const { tabLabels, lazy } = props.entity.attributes;
     const children = props.children ?? [];
     return (
-      <div className="space-y-4">
+      <TabView renderActiveOnly={lazy ?? true} className="mt-2">
         {tabLabels.map((label, index) => (
-          <div key={index} className="grid gap-2">
-            <h3 className="text-lg font-medium">{label}</h3>
+          <TabPanel key={index} header={label}>
             {children[index] ?? null}
-          </div>
+          </TabPanel>
         ))}
-      </div>
+      </TabView>
     );
   },
 );

--- a/app/builders/basic-form-builder/entities/tabs/definition.ts
+++ b/app/builders/basic-form-builder/entities/tabs/definition.ts
@@ -1,8 +1,9 @@
 import { createEntity } from "@coltorapps/builder";
 import { tabLabelsAttribute } from "../../attributes/tab-labels/definition";
+import { lazyAttribute } from "../../attributes/lazy/definition";
 
 export const tabsEntity = createEntity({
   name: "tabs",
-  attributes: [tabLabelsAttribute],
+  attributes: [tabLabelsAttribute, lazyAttribute],
   childrenAllowed: true,
 });

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,5 +1,8 @@
 @import "tailwindcss";
 @import "tw-animate-css";
+@import "primereact/resources/themes/lara-dark-blue/theme.css";
+@import "primereact/resources/primereact.min.css";
+@import "primeicons/primeicons.css";
 
 @custom-variant dark (&:is(.dark *));
 

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -39,7 +39,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 min-w-[8rem] overflow-hidden rounded-md border shadow-md",
+        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-[60] min-w-[8rem] overflow-hidden rounded-md border shadow-md",
         position === "popper" &&
           "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
         className,

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -13,7 +13,7 @@ const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      "bg-muted text-muted-foreground inline-flex h-10 items-center justify-center rounded-full p-1",
+      "border-b border-border flex items-center space-x-2",
       className,
     )}
     {...props}
@@ -28,7 +28,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "ring-offset-background focus-visible:ring-ring data-[state=active]:bg-background data-[state=active]:text-foreground inline-flex items-center justify-center whitespace-nowrap rounded-full px-3 py-1 text-sm font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm",
+      "border-b-2 border-transparent px-3 py-2 text-sm font-medium text-muted-foreground transition-colors data-[state=active]:border-primary data-[state=active]:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
       className,
     )}
     {...props}
@@ -36,12 +36,18 @@ const TabsTrigger = React.forwardRef<
 ));
 TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
 
+interface TabsContentProps
+  extends React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content> {
+  lazy?: boolean;
+}
+
 const TabsContent = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
->(({ className, ...props }, ref) => (
+  TabsContentProps
+>(({ className, lazy = false, ...props }, ref) => (
   <TabsPrimitive.Content
     ref={ref}
+    forceMount={!lazy}
     className={cn(
       "ring-offset-background focus-visible:ring-ring mt-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
       className,

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "date-fns": "^4.1.0",
     "lucide-react": "^0.525.0",
     "next": "15.3.5",
+    "primeicons": "^7.0.0",
+    "primereact": "^10.9.6",
     "radix-ui": "^1.4.2",
     "react": "^19.0.0",
     "react-day-picker": "^9.7.0",


### PR DESCRIPTION
## Summary
- include PrimeReact dependencies and import theme styles
- switch tabs entity rendering to PrimeReact TabView
- replace builder preview tabs with PrimeReact TabView

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find module '@markdoc/markdoc')*

------
https://chatgpt.com/codex/tasks/task_e_686d31cfaaf48330b565d493b38e5c77